### PR TITLE
fix(imhex): settings cannot be saved due to portable mode

### DIFF
--- a/imhex/tools/chocolateyinstall.ps1
+++ b/imhex/tools/chocolateyinstall.ps1
@@ -16,3 +16,4 @@ Install-ChocolateyZipPackage @installArgs
 
 $installDir = $toolsDir
 New-Item "$(Join-Path $installDir 'ImHex.exe.gui')" -type file -Force | Out-Null
+Remove-Item "$(Join-Path $installDir 'PORTABLE')" -Force | Out-Null


### PR DESCRIPTION
The settings in imhex could not be saved before, because imhex assumed it was running as a portable version. Deleting the "PORTABLE" file in the installation directory during the installation process fixes this issue.

https://github.com/WerWolv/ImHex/issues/1166